### PR TITLE
Use `openlineage.airflow` lib

### DIFF
--- a/airflow/dags/delivery_times_7_days.py
+++ b/airflow/dags/delivery_times_7_days.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/email_discounts.py
+++ b/airflow/dags/email_discounts.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_categories.py
+++ b/airflow/dags/etl_categories.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_customers.py
+++ b/airflow/dags/etl_customers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_delivery_7_days.py
+++ b/airflow/dags/etl_delivery_7_days.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_drivers.py
+++ b/airflow/dags/etl_drivers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_menu_items.py
+++ b/airflow/dags/etl_menu_items.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_menus.py
+++ b/airflow/dags/etl_menus.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_order_status.py
+++ b/airflow/dags/etl_order_status.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_orders.py
+++ b/airflow/dags/etl_orders.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_orders_7_days.py
+++ b/airflow/dags/etl_orders_7_days.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/etl_restaurants.py
+++ b/airflow/dags/etl_restaurants.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 

--- a/airflow/dags/orders_popular_day_of_week.py
+++ b/airflow/dags/orders_popular_day_of_week.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from marquez_airflow import DAG
+from openlineage.airflow import DAG
 from airflow.operators.postgres_operator import PostgresOperator
 from airflow.utils.dates import days_ago
 


### PR DESCRIPTION
This PR updates our demo dags to use the `openlineage.airflow` lib.